### PR TITLE
Support cordova-plugin-ionic-webview@2.x.x to cordova-plugin-ionic-webview@4.x.x localStorage migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _* Only on iOS_
 Straight forward, just via `cordova plugin add`.
 
 ```
-cordova plugin add https://github.com/GartorwareCorp/cordova-plugin-ionic-migrate-storage#v0.2.0 --save
+cordova plugin add https://github.com/styleseat/cordova-plugin-ionic-migrate-storage --save
 ```
 
 **The plugin uses [the `WKPort` preference supplied to the ionic webview](https://github.com/ionic-team/cordova-plugin-ionic-webview/tree/2.x#wkport) for cordova-plugin-ionic-webview v2x version. If that was not found, the default port is used (`8080`). (Not tested)**
@@ -27,21 +27,21 @@ To test this, you will have to do the following:
 * Remove the webview and migrate plugins from your app:
 
 ```
-cordova plugin rm --save cordova-plugin-ionic-webview @gartorware/cordova-plugin-ionic-migrate-storage
+cordova plugin rm --save cordova-plugin-ionic-webview @styleseat/cordova-plugin-ionic-migrate-storage
 ```
 
 * Build your app and run it. Store something in localStorage, WebSQL and IndexedDB.
 * Add the plugins back:
         
 ```
-cordova plugin add --save cordova-plugin-ionic-webview@4.0.1 https://github.com/GartorwareCorp/cordova-plugin-ionic-migrate-storage#v0.2.0
+cordova plugin add --save cordova-plugin-ionic-webview@4.0.1 https://github.com/styleseat/cordova-plugin-ionic-migrate-storage
 ```
 
 * Build your app and run it. The stored data must all exist!
 
 ## Caveats / Warnings / Gotchas
 
-* Until the plugin reaches `v.1.0.0`, breaking changes will be introduced in every minor version upgrade! Use one of [the tags listed here](https://github.com/GartorwareCorp/cordova-plugin-ionic-migrate-storage/releases) if you want to lock it down to a specific changeset.
+* Until the plugin reaches `v.1.0.0`, breaking changes will be introduced in every minor version upgrade! Use one of [the tags listed here](https://github.com/styleseat/cordova-plugin-ionic-migrate-storage/releases) if you want to lock it down to a specific changeset.
 * **This has been tested only with `android` and `cordova-plugin-ionic-webview@4.0.1`!**
 * Currently, this plugin does not work on simulators. PRs welcome!
 * IndexedDB migration has not been implemented in Android, because [it looks tricky](https://stackoverflow.com/a/35142175).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # `cordova-plugin-ionic-migrate-storage`
 
-> Cordova plugin that migrates WebSQL, localStorage and IndexedDB* data when you start using the `cordova-plugin-ionic-webview` plugin. This works for both Android and iOS!
-
-_* Only on iOS_
+> Cordova plugin that migrates localStorage data from cordova-plugin-ionic-webview@2.X.X to cordova-plugin-ionic-webview@3.X.X and above. This works for both Android and iOS!
 
 ## Installation
 
@@ -12,11 +10,29 @@ Straight forward, just via `cordova plugin add`.
 cordova plugin add https://github.com/styleseat/cordova-plugin-ionic-migrate-storage --save
 ```
 
-**The plugin uses [the `WKPort` preference supplied to the ionic webview](https://github.com/ionic-team/cordova-plugin-ionic-webview/tree/2.x#wkport) for cordova-plugin-ionic-webview v2x version. If that was not found, the default port is used (`8080`). (Not tested)**
+This work is forked from https://github.com/pointmanhq/cordova-plugin-ionic-migrate-storage, which migrates IndexedDB, LocalStorage, and WebSQL from cordova's default UIWebView to cordova-plugin-ionic-webview. We needed to migrate not from the default UIWebView, but from cordova-plugin-ionic-webview@2.X.X to cordova-plugin-ionic-webview@4.X.X, and only localStorage was needed, so IndexedDB and WebSQL support were removed and the migration locations were made configurable. Theoretically, this plugin could also be used to migrate from UIWebView to cordova-plugin-ionic-migrate-storage. The following settings are configurable (defaults listed):
 
-**The plugin uses [the `hostname` preference supplied to the ionic webview](https://github.com/ionic-team/cordova-plugin-ionic-webview#hostname) for cordova-plugin-ionic-webview v3x/v4x version. If that was not found, the default hostname is used (`localhost`).**
 
-**The plugin uses [the `scheme` preference supplied to the ionic webview](https://github.com/ionic-team/cordova-plugin-ionic-webview#scheme) for cordova-plugin-ionic-webview v3x/v4x version. If that was not found, the default scheme is used (`http`).**
+#define DEFAULT_TARGET_HOSTNAME @"localhost"
+#define DEFAULT_TARGET_SCHEME @"ionic"
+#define DEFAULT_TARGET_PORT_NUMBER @"0"
+
+#define DEFAULT_ORIGINAL_HOSTNAME @"localhost"
+#define DEFAULT_ORIGINAL_SCHEME @"http"
+#define DEFAULT_ORIGINAL_PORT_NUMBER @"8080"
+
+```xml
+<!-- cordova-plugin-ionic-webview@4.x.x defaults to serving from http://localhost on Android and ionic://localhost on iOS -->
+<preference name="Scheme" value="http" />
+<preference name="iosScheme" value="ionic" />
+<preference name="Hostname" value="localhost" />
+<preference name="WKPort" value="" />
+
+<!-- cordova-plugin-ionic-webview@2.x.x defaults to serving from http://localhost:8080 -->
+<preference name="MIGRATE_STORAGE_ORIGINAL_SCHEME" value="http" />
+<preference name="MIGRATE_STORAGE_ORIGINAL_HOSTNAME" value="localhost" />
+<preference name="MIGRATE_STORAGE_ORIGINAL_PORT_NUMBER" value="8080" />
+```
 
 
 ## Testing
@@ -42,10 +58,8 @@ cordova plugin add --save cordova-plugin-ionic-webview@4.0.1 https://github.com/
 ## Caveats / Warnings / Gotchas
 
 * Until the plugin reaches `v.1.0.0`, breaking changes will be introduced in every minor version upgrade! Use one of [the tags listed here](https://github.com/styleseat/cordova-plugin-ionic-migrate-storage/releases) if you want to lock it down to a specific changeset.
-* **This has been tested only with `android` and `cordova-plugin-ionic-webview@4.0.1`!**
+* **This has only been tested with `android` and `ios`, migrating from `cordova-plugin-ionic-webview@2.2.5` to `cordova-plugin-ionic-webview@4.1.0`!**
 * Currently, this plugin does not work on simulators. PRs welcome!
-* IndexedDB migration has not been implemented in Android, because [it looks tricky](https://stackoverflow.com/a/35142175).
-* IndexedDB migration on iOS may be buggy, a PR or two will be needed to make it better. 
 * This copy is uni-directional, from old webview to new webview. It does not go the other way around. So essentially, this plugin will run only once! 
 * **Once again!**: **This has been tested only with `android` and `cordova-plugin-ionic-webview@4.0.1`!**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@gartorware/cordova-plugin-ionic-migrate-storage",
-  "version": "0.2.0",
+  "name": "@styleseat/cordova-plugin-ionic-migrate-storage",
+  "version": "0.3.0",
   "cordova": {
     "id": "cordova-plugin-ionic-migrate-storage",
     "platforms": [
@@ -15,5 +15,5 @@
   },
   "keywords": ["ecosystem:cordova", "cordova", "cordova-plugin", "cordova-ios", "cordova-android", "ios", "android", "uiwebview", "wkwebview", "websql", "localstorage", "indexeddb"],
   "author": "Pointman Dev <dev@pointman.com>",
-  "contributors": ["Gartorware <gartorware@gmail.com>"]
+  "contributors": ["Gartorware <gartorware@gmail.com>", "StyleSeat <engineering@styleseat.com>"]
 }

--- a/src/android/MigrateStorage.java
+++ b/src/android/MigrateStorage.java
@@ -90,7 +90,7 @@ public class MigrateStorage extends CordovaPlugin {
     }
 
     /**
-     * Migrate localStorage from `{prevScheme}://{prevHostname}` to `{newScheme}://{newHostname}`
+     * Migrate localStorage from `{prevScheme}://{prevHostname}:{prevPort}` to `{newScheme}://{newHostname}:{newPort}`
      *
      * @throws Exception - Can throw LevelDBException
      */
@@ -127,16 +127,14 @@ public class MigrateStorage extends CordovaPlugin {
         // To update in bulk!
         WriteBatch batch = new WriteBatch();
 
-        // 🔃 Loop through the keys and replace `file://` with `{scheme}://{hostname}`
+        // 🔃 Loop through the keys and replace `{prevScheme}://{prevHostname}:{prevPort}` with `{newScheme}://{newHostname}:{newPort}`
         logDebug("migrateLocalStorage: Starting replacements;");
         for(iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
             String key = Utils.bytesToString(iterator.key());
             byte[] value = iterator.value();
             if (key.startsWith(prevLocalStorageKeyPrefix) || key.equals(prevLocalStorageMetaKey)) {
                 String newKey = key.replace(prevLocalStorageBaseURL, newLocalStorageBaseURL);
-
                 logDebug("migrateLocalStorage: Changing key: " + key + " to '" + newKey + "'");
-
                 // Add new key to db
                 batch.putBytes(Utils.stringToBytes(newKey), value);
             } else {

--- a/src/android/MigrateStorage.java
+++ b/src/android/MigrateStorage.java
@@ -1,7 +1,6 @@
 package com.migrate.android;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
 import com.appunite.leveldb.LevelDB;
@@ -28,46 +27,51 @@ import java.io.File;
  */
 public class MigrateStorage extends CordovaPlugin {
     // Switch this value to enable debug mode
-    private static final boolean DEBUG_MODE = false;
+    private static final boolean DEBUG_MODE = true;
 
     private static final String TAG = "com.migrate.android";
-    private static final String FILE_PROTOCOL = "file://";
-    private static final String WEBSQL_FILE_DIR_NAME = "file__0";
-    private static final String DEFAULT_HOSTNAME = "localhost";
-    private static final String DEFAULT_SCHEME = "http";
+    private static final String DEFAULT_NEW_HOSTNAME = "localhost";
+    private static final String DEFAULT_NEW_SCHEME = "http";
+    private static final String DEFAULT_NEW_PORT_NUMBER = "";
 
-    private static final String CDV_SETTING_PORT_NUMBER = "WKPort";
-    private static final String SETTING_HOSTNAME = "Hostname";
-    private static final String SETTING_SCHEME = "Scheme";
+    private static final String DEFAULT_PREV_HOSTNAME = "localhost";
+    private static final String DEFAULT_PREV_SCHEME = "http";
+    private static final String DEFAULT_PREV_PORT_NUMBER = "8080";
 
-    private String portNumber;
-    private String hostname;
-    private String scheme;
+    private static final String SETTING_NEW_PORT_NUMBER = "WKPort";
+    private static final String SETTING_NEW_HOSTNAME = "Hostname";
+    private static final String SETTING_NEW_SCHEME = "Scheme";
+
+    private static final String SETTING_PREV_PORT_NUMBER = "MIGRATE_STORAGE_PREV_PORT_NUMBER";
+    private static final String SETTING_PREV_HOSTNAME = "MIGRATE_STORAGE_PREV_HOSTNAME";
+    private static final String SETTING_PREV_SCHEME = "MIGRATE_STORAGE_PREV_SCHEME";
+
+    private static final String KEY_SEPARATOR_BYTES = "\u0000\u0001";
+
+    private String prevPortNumber;
+    private String prevHostname;
+    private String prevScheme;
+
+    private String newPortNumber;
+    private String newHostname;
+    private String newScheme;
 
     private void logDebug(String message) {
         if(DEBUG_MODE) Log.d(TAG, message);
     }
 
-    private String getLocalHostProtocolDirName() {
-        return "http_localhost_" + this.portNumber;
-    }
-
-    private String getWebSQLDirName() {
-        String result = this.scheme + "_" + this.hostname;
-        if(this.portNumber != null && !this.portNumber.isEmpty()) {
-            result += "_" + this.portNumber;
+    private String getPrevLocalStorageBaseURL() {
+        String result = this.prevScheme + "://" + this.prevHostname;
+        if(this.prevPortNumber != null && !this.prevPortNumber.isEmpty()) {
+            result += ":" + this.prevPortNumber;
         }
         return result;
     }
 
-    private String getLocalHostProtocol() {
-        return "http://localhost:" + this.portNumber;
-    }
-
-    private String getLocalStorageProtocol() {
-        String result = this.scheme + "://" + this.hostname;
-        if(this.portNumber != null && !this.portNumber.isEmpty()) {
-            result += ":" + this.portNumber;
+    private String getNewLocalStorageBaseURL() {
+        String result = this.newScheme + "://" + this.newHostname;
+        if(this.newPortNumber != null && !this.newPortNumber.isEmpty()) {
+            result += ":" + this.newPortNumber;
         }
         return result;
     }
@@ -85,18 +89,8 @@ public class MigrateStorage extends CordovaPlugin {
         return this.getWebViewRootPath() + "/Local Storage";
     }
 
-    private String getWebSQLDatabasesPath() {
-        return this.getWebViewRootPath() + "/databases";
-    }
-
-    private String getWebSQLReferenceDbPath() {
-        return this.getWebSQLDatabasesPath() + "/Databases.db";
-    }
-
     /**
-     * Migrate localStorage from `file://` to `{scheme}://{hostname}`
-     *
-     * TODO Test if we can we remove old file:// keys?
+     * Migrate localStorage from `{prevScheme}://{prevHostname}` to `{newScheme}://{newHostname}`
      *
      * @throws Exception - Can throw LevelDBException
      */
@@ -114,10 +108,15 @@ public class MigrateStorage extends CordovaPlugin {
 
         LevelDB db = new LevelDB(levelDbPath);
 
-        String localStorageProtocol = this.getLocalStorageProtocol();
+        String prevLocalStorageBaseURL = this.getPrevLocalStorageBaseURL();
+        String prevLocalStorageMetaKey = "META:" + prevLocalStorageBaseURL;
+        String prevLocalStorageKeyPrefix = "_" + prevLocalStorageBaseURL + KEY_SEPARATOR_BYTES;
 
-        if(db.exists(Utils.stringToBytes("META:" + localStorageProtocol))) {
-            this.logDebug("migrateLocalStorage: Found 'META:" + localStorageProtocol + "' key; Skipping migration");
+        String newLocalStorageBaseURL = this.getNewLocalStorageBaseURL();
+        String newLocalStorageMetaKey = "META:" + newLocalStorageBaseURL;
+
+        if(db.exists(Utils.stringToBytes(newLocalStorageMetaKey))) {
+            this.logDebug("migrateLocalStorage: Found '" + newLocalStorageMetaKey + "' key; Skipping migration");
             db.close();
             return;
         }
@@ -133,9 +132,8 @@ public class MigrateStorage extends CordovaPlugin {
         for(iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
             String key = Utils.bytesToString(iterator.key());
             byte[] value = iterator.value();
-
-            if (key.contains(FILE_PROTOCOL)) {
-                String newKey = key.replace(FILE_PROTOCOL, localStorageProtocol);
+            if (key.startsWith(prevLocalStorageKeyPrefix) || key.equals(prevLocalStorageMetaKey)) {
+                String newKey = key.replace(prevLocalStorageBaseURL, newLocalStorageBaseURL);
 
                 logDebug("migrateLocalStorage: Changing key: " + key + " to '" + newKey + "'");
 
@@ -157,56 +155,6 @@ public class MigrateStorage extends CordovaPlugin {
 
 
     /**
-     * Migrate WebSQL from using `file://` to `{scheme}://{hostname}`
-     *
-     */
-    private void migrateWebSQL() {
-        this.logDebug("migrateWebSQL: Migrating WebSQL..");
-
-        String databasesPath = this.getWebSQLDatabasesPath();
-        String referenceDbPath = this.getWebSQLReferenceDbPath();
-        String webSqlDirName = this.getWebSQLDirName();
-
-        if(!new File(referenceDbPath).exists()) {
-            logDebug("migrateWebSQL: Databases.db was not found in path: '" + referenceDbPath + "'; Exiting..");
-            return;
-        }
-
-        File originalWebSQLDir = new File(databasesPath + "/" + WEBSQL_FILE_DIR_NAME);
-        File targetWebSQLDir = new File(databasesPath + "/" + webSqlDirName);
-
-        if(!originalWebSQLDir.exists()) {
-            logDebug("migrateWebSQL: original DB does not exist at '" + originalWebSQLDir.getAbsolutePath() + "'; Exiting..");
-            return;
-        }
-
-        if(targetWebSQLDir.exists()) {
-            logDebug("migrateWebSQL: target DB already exists at '" + targetWebSQLDir.getAbsolutePath() + "'; Skipping..");
-            return;
-        }
-
-        logDebug("migrateWebSQL: Databases.db path: '" + referenceDbPath + "';");
-
-        SQLiteDatabase db = SQLiteDatabase.openDatabase(referenceDbPath, null, 0);
-
-        // Update reference DB to point to `localhost:{portNumber}`
-        db.execSQL("UPDATE Databases SET origin = ? WHERE origin = ?", new String[] { webSqlDirName, WEBSQL_FILE_DIR_NAME });
-        
-        // rename `databases/file__0` dir to `databases/localhost_http_{portNumber}`
-        boolean renamed = originalWebSQLDir.renameTo(targetWebSQLDir);
-
-        if(!renamed) {
-            logDebug("migrateWebSQL: Tried renaming '" + originalWebSQLDir.getAbsolutePath() + "' to '" + targetWebSQLDir.getAbsolutePath() + "' but failed; Exiting...");
-            return;
-        }
-        
-        db.close();
-
-        this.logDebug("migrateWebSQL: Successfully migrated WebSQL..");
-    }
-
-
-    /**
      * Sets up the plugin interface
      *
      * @param cordova - cdvInterface that contains cordova goodies
@@ -216,18 +164,37 @@ public class MigrateStorage extends CordovaPlugin {
         try {
             super.initialize(cordova, webView);
 
-            this.portNumber = this.preferences.getString(CDV_SETTING_PORT_NUMBER, "");
+            this.prevPortNumber = this.preferences.getString(SETTING_PREV_PORT_NUMBER, "");
+            if(this.prevPortNumber == null || this.prevPortNumber.isEmpty()) {
+                this.prevPortNumber = DEFAULT_PREV_PORT_NUMBER;
+            }
+            this.prevHostname = this.preferences.getString(SETTING_PREV_HOSTNAME, "");
+            if(this.prevHostname == null || this.prevHostname.isEmpty()) {
+                this.prevHostname = DEFAULT_PREV_HOSTNAME;
+            }
+            this.prevScheme = this.preferences.getString(SETTING_PREV_SCHEME, "");
+            if(this.prevScheme == null || this.prevScheme.isEmpty()) {
+                this.prevScheme = DEFAULT_PREV_SCHEME;
+            }
 
-            this.hostname = this.preferences.getString(SETTING_HOSTNAME, "");
-            if(this.hostname.isEmpty() || this.hostname == null) this.hostname = DEFAULT_HOSTNAME;
+            this.newPortNumber = this.preferences.getString(SETTING_NEW_PORT_NUMBER, "");
+            if(this.newPortNumber == null || this.newPortNumber.isEmpty()) {
+                this.newPortNumber = DEFAULT_NEW_PORT_NUMBER;
+            }
 
-            this.scheme = this.preferences.getString(SETTING_SCHEME, "");
-            if(this.scheme.isEmpty() || this.scheme == null) this.scheme = DEFAULT_SCHEME;
+            this.newHostname = this.preferences.getString(SETTING_NEW_HOSTNAME, "");
+            if(this.newHostname == null || this.newHostname.isEmpty()) {
+                this.newHostname = DEFAULT_NEW_HOSTNAME;
+            }
+
+            this.newScheme = this.preferences.getString(SETTING_NEW_SCHEME, "");
+            if(this.newScheme == null || this.newScheme.isEmpty()) {
+                this.newScheme = DEFAULT_NEW_SCHEME;
+            }
 
             logDebug("Starting migration;");
 
             this.migrateLocalStorage();
-            this.migrateWebSQL();
 
             logDebug("Migration completed;");
         } catch (Exception ex) {

--- a/src/ios/MigrateStorage.m
+++ b/src/ios/MigrateStorage.m
@@ -15,34 +15,51 @@
 
 #define TAG @"\nMigrateStorage"
 
-// TODO Make these paths simpler to deal with? We could embded the full paths in these strings if we want to...
-#define ORIG_DIRPATH @"WebKit/LocalStorage/"
-#define TARGET_DIRPATH @"WebKit/WebsiteData/"
+#define LOCALSTORAGE_DIRPATH @"WebKit/WebsiteData/LocalStorage/"
 
-#define ORIG_WEBSQL_DIRPATH @"WebKit/LocalStorage/"
-#define TARGET_WEBSQL_DIRPATH @"WebKit/WebsiteData/WebSQL/"
+#define DEFAULT_TARGET_HOSTNAME @"localhost"
+#define DEFAULT_TARGET_SCHEME @"ionic"
+#define DEFAULT_TARGET_PORT_NUMBER @""
 
-#define ORIG_LS_DIRPATH @"WebKit/LocalStorage/"
-#define ORIG_LS_CACHE_DIRPATH @"Caches/"
-#define TARGET_LS_DIRPATH @"WebKit/WebsiteData/LocalStorage/"
+#define DEFAULT_ORIGINAL_HOSTNAME @"localhost"
+#define DEFAULT_ORIGINAL_SCHEME @"http"
+#define DEFAULT_ORIGINAL_PORT_NUMBER @"8080"
 
-#define ORIG_IDB_DIRPATH @"WebKit/LocalStorage/___IndexedDB/"
-#define TARGET_IDB_DIRPATH @"WebKit/WebsiteData/IndexedDB/"
+#define SETTING_TARGET_PORT_NUMBER @"WKPort"
+#define SETTING_TARGET_HOSTNAME @"Hostname"
+#define SETTING_TARGET_SCHEME @"iosScheme"
 
-#define UI_WEBVIEW_PROTOCOL_DIR @"file__0"
-
-#define CDV_SETTING_PORT_NUMBER @"WKPort"
-#define DEFAULT_PORT_NUMBER @"8080"
+#define SETTING_ORIGINAL_PORT_NUMBER @"MIGRATE_STORAGE_ORIGINAL_PORT_NUMBER"
+#define SETTING_ORIGINAL_HOSTNAME @"MIGRATE_STORAGE_ORIGINAL_HOSTNAME"
+#define SETTING_ORIGINAL_SCHEME @"MIGRATE_STORAGE_ORIGINAL_SCHEME"
 
 @interface MigrateStorage ()
-    @property (nonatomic, assign) NSString *portNumber;
+    @property (nonatomic, assign) NSString *originalPortNumber;
+    @property (nonatomic, assign) NSString *originalHostname;
+    @property (nonatomic, assign) NSString *originalScheme;
+    @property (nonatomic, assign) NSString *targetPortNumber;
+    @property (nonatomic, assign) NSString *targetHostname;
+    @property (nonatomic, assign) NSString *targetScheme;
 @end
 
 @implementation MigrateStorage
 
-- (NSString*)getWkWebviewProtocolDir
+- (NSString*)getOriginalPath
 {
-    return [@"http_localhost_" stringByAppendingString:self.portNumber];
+    NSString *path = [NSString stringWithFormat:@"%@_%@", self.originalScheme, self.originalHostname];
+    if (self.originalPortNumber) {
+        path = [path stringByAppendingFormat: @"_%@", self.originalPortNumber];
+    }
+    return path;
+}
+
+- (NSString*)getTargetPath
+{
+    NSString *path = [NSString stringWithFormat:@"%@_%@", self.targetScheme, self.targetHostname];
+    if (self.targetPortNumber) {
+        path = [path stringByAppendingFormat: @"_%@", self.targetPortNumber];
+    }
+    return path;
 }
 
 - (BOOL)moveFile:(NSString*)src to:(NSString*)dest
@@ -77,159 +94,38 @@
     return res;
 }
 
-- (BOOL)changeProtocolEntriesinReferenceDB:(NSString *)path from:(NSString *)srcProtocolDir to:(NSString *)targetProtocolDir
-{
-    logDebug(@"%@ changeProtocolEntriesinReferenceDB()", TAG);
-    
-    FMDatabase *db = [FMDatabase databaseWithPath:path];
-    
-    // Can't do anything, just let this fail and let WkWebview create its own DB! :(
-    if(![db open])
-    {
-        
-        logDebug(@"%@ dbOpen error: %@ ; exiting..", TAG, [db lastErrorMessage]);
-        return NO;
-    }
-    
-    BOOL success = [db executeUpdate:@"UPDATE Databases SET origin = ? WHERE origin = ?", targetProtocolDir, srcProtocolDir];
-    if (!success)
-    {
-        logDebug(@"%@ executeUpdate error for `Databases` table update = %@", TAG, [db lastErrorMessage]);
-    }
-    
-    
-    success = [db executeUpdate:@"UPDATE Origins SET origin = ? WHERE origin = ?", targetProtocolDir, srcProtocolDir];
-    if (!success)
-    {
-        logDebug(@"%@ executeUpdate error for `Origins` table update = %@", TAG, [db lastErrorMessage]);
-    }
-    
-    [db close];
-    
-    logDebug(@"%@ end changeProtocolEntriesinReferenceDB()", TAG);
-    
-    return success;
-}
-
-- (BOOL)migrateWebSQL
-{
-    logDebug(@"%@ migrateWebSQL()", TAG);
-    
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSString *appLibraryDir = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    
-    NSString *uiWebViewRootPath = [appLibraryDir stringByAppendingPathComponent:ORIG_WEBSQL_DIRPATH];
-    NSString *wkWebViewRootPath = [appLibraryDir stringByAppendingPathComponent:TARGET_WEBSQL_DIRPATH];
-    
-    //
-    // Copy {appLibrary}/WebKit/LocalStorage/Databases.db to {appLibrary}/WebKit/WebsiteData/WebSQL/Databases.db
-    //
-    
-    // "Databases.db" contains an "index" of all the WebSQL databases that the app is using
-    NSString *uiWebViewRefDBPath = [uiWebViewRootPath stringByAppendingPathComponent:@"Databases.db"];
-    NSString *wkWebViewRefDBPath = [wkWebViewRootPath stringByAppendingPathComponent:@"Databases.db"];
-    
-    // Exit away if the source file does not exist
-    if(![fileManager fileExistsAtPath:uiWebViewRefDBPath])
-    {
-        logDebug(@"%@ source path not found: %@ ; exiting..", TAG, uiWebViewRefDBPath);
-        return NO;
-    }
-    
-    // TODO Check if target file exists or not?
-    
-    NSString *wkWebviewProtocolDir = [self getWkWebviewProtocolDir];
-    
-    // Before copying, open Databases.db and change the reference from `file__0` to `localhost_http_{portNumber}`, so WkWebView will understand this
-    if (![self changeProtocolEntriesinReferenceDB:uiWebViewRefDBPath from:UI_WEBVIEW_PROTOCOL_DIR to:wkWebviewProtocolDir])
-    {
-        logDebug(@"%@ could not perform needed update; exiting..", TAG);
-        return NO;
-    }
-    
-    
-    BOOL success1 = [self moveFile:uiWebViewRefDBPath to:wkWebViewRefDBPath];
-    BOOL success2 = [self moveFile:[uiWebViewRefDBPath stringByAppendingString:@"-shm"] to:[wkWebViewRefDBPath stringByAppendingString:@"-shm"]];
-    BOOL success3 = [self moveFile:[uiWebViewRefDBPath stringByAppendingString:@"-wal"] to:[wkWebViewRefDBPath stringByAppendingString:@"-wal"]];
-    
-    if(!success1 || !success2 || !success3)
-    {
-        logDebug(@"%@ could not move Databases.db; exiting..", TAG);
-        return NO;
-    }
-    
-    //
-    // Move
-    //  {appLibrary}/WebKit/LocalStorage/file__0/*
-    // to
-    //  {appLibrary}/WebKit/WebsiteData/WebSQL/http_localhost_{portNumber}/*
-    //
-    
-    // This dir contains all the WebSQL Databases that the cordova app
-    NSString *uiWebViewDBFileDir = [uiWebViewRootPath stringByAppendingPathComponent:UI_WEBVIEW_PROTOCOL_DIR];
-    
-    
-    // The target dir that should contain all the databases from `uiWebViewDBFileDir`
-    NSString *wkWebViewDBFileDir = [wkWebViewRootPath stringByAppendingPathComponent:wkWebviewProtocolDir];
-    
-    NSArray *fileList = [fileManager contentsOfDirectoryAtPath:uiWebViewDBFileDir error:nil];
-    
-    // Exit if no databases were found
-    // This should never happen, because if no databases were found, we would not have found the `Databases.db` file!
-    if ([fileList count] == 0) return NO;
-    
-    BOOL success;
-    
-    for (NSString *fileName in fileList) {
-        NSString *originalFilePath = [uiWebViewDBFileDir stringByAppendingPathComponent:fileName];
-        NSString *targetFilePath = [wkWebViewDBFileDir stringByAppendingPathComponent:fileName];
-        
-        success = [self moveFile:originalFilePath to:targetFilePath];
-    }
-    
-    if(!success)
-    {
-        logDebug(@"%@ could not move one of the databases in %@ ; exiting..", TAG, uiWebViewDBFileDir);
-        return NO;
-    }
-    
-    logDebug(@"%@ end migrateWebSQL() with success: %@", TAG, success ? @"YES" : @"NO");
-    return YES;
-}
-
 - (BOOL) migrateLocalStorage
 {
     logDebug(@"%@ migrateLocalStorage()", TAG);
     
     BOOL success;
-    NSString *wkWebviewProtocolDir = [self getWkWebviewProtocolDir];
+    NSString *originalPath = [self getOriginalPath];
+    NSString *targetPath = [self getTargetPath];
     
     NSString *appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     
-    NSString *originalLSFileName = [UI_WEBVIEW_PROTOCOL_DIR stringByAppendingString:@".localstorage"];
-    NSString *targetLSFileName = [wkWebviewProtocolDir stringByAppendingString:@".localstorage"];
+    NSString *originalLocalStorageFileName = [originalPath stringByAppendingString:@".localstorage"];
+
+    NSString *targetLocalStorageFileName = [targetPath stringByAppendingString:@".localstorage"];
     
-    NSString *originalLSFilePath = [[appLibraryFolder stringByAppendingPathComponent:ORIG_LS_DIRPATH] stringByAppendingPathComponent:originalLSFileName];
-    NSString *originalLSCachePath = [[appLibraryFolder stringByAppendingPathComponent:ORIG_LS_CACHE_DIRPATH] stringByAppendingPathComponent:originalLSFileName];
+    NSString *originalLocalStorageFilePath = [[appLibraryFolder stringByAppendingPathComponent:LOCALSTORAGE_DIRPATH] stringByAppendingPathComponent:originalLocalStorageFileName];
     
-    // Use the file in the cache if not found in original path
-    NSString *original = [[NSFileManager defaultManager] fileExistsAtPath:originalLSFilePath] ? originalLSFilePath : originalLSCachePath;
-    NSString *target = [[appLibraryFolder stringByAppendingPathComponent:TARGET_LS_DIRPATH] stringByAppendingPathComponent:targetLSFileName];
+    NSString *targetLocalStorageFilePath = [[appLibraryFolder stringByAppendingPathComponent:LOCALSTORAGE_DIRPATH] stringByAppendingPathComponent:targetLocalStorageFileName];
     
-    logDebug(@"%@ LS original %@", TAG, original);
-    logDebug(@"%@ LS target %@", TAG, target);
+    logDebug(@"%@ LocalStorage original %@", TAG, original);
+    logDebug(@"%@ LocalStorage target %@", TAG, target);
     
     // Only copy data if no existing localstorage data exists yet for wkwebview
-    if (![[NSFileManager defaultManager] fileExistsAtPath:target]) {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:targetLocalStorageFilePath]) {
         logDebug(@"%@ No existing localstorage data found for WKWebView. Migrating data from UIWebView", TAG);
-        BOOL success1 = [self moveFile:original to:target];
-        BOOL success2 = [self moveFile:[original stringByAppendingString:@"-shm"] to:[target stringByAppendingString:@"-shm"]];
-        BOOL success3 = [self moveFile:[original stringByAppendingString:@"-wal"] to:[target stringByAppendingString:@"-wal"]];
+        BOOL success1 = [self moveFile:originalLocalStorageFilePath to:targetLocalStorageFilePath];
+        BOOL success2 = [self moveFile:[originalLocalStorageFilePath stringByAppendingString:@"-shm"] to:[targetLocalStorageFilePath stringByAppendingString:@"-shm"]];
+        BOOL success3 = [self moveFile:[originalLocalStorageFilePath stringByAppendingString:@"-wal"] to:[targetLocalStorageFilePath stringByAppendingString:@"-wal"]];
         logDebug(@"%@ copy status %d %d %d", TAG, success1, success2, success3);
         success = success1 && success2 && success3;
     }
     else {
-        logDebug(@"%@ found LS data. not migrating", TAG);
+        logDebug(@"%@ found LocalStorage data. not migrating", TAG);
         success = NO;
     }
     
@@ -238,47 +134,43 @@
     return success;
 }
 
-- (BOOL) migrateIndexedDB
-{
-    logDebug(@"%@ migrateIndexedDB()", TAG);
-    
-    NSString *wkWebviewProtocolDir = [self getWkWebviewProtocolDir];
-    
-    NSString *appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    
-    NSString *original = [[appLibraryFolder stringByAppendingPathComponent:ORIG_IDB_DIRPATH] stringByAppendingPathComponent:UI_WEBVIEW_PROTOCOL_DIR];
-    NSString *target = [[appLibraryFolder stringByAppendingPathComponent:TARGET_IDB_DIRPATH] stringByAppendingPathComponent:wkWebviewProtocolDir];
-    
-    logDebug(@"%@ IDB original %@", TAG, original);
-    logDebug(@"%@ IDB target %@", TAG, target);
-    
-    if (![[NSFileManager defaultManager] fileExistsAtPath:target]) {
-        logDebug(@"%@ No existing IDB data found for WKWebView. Migrating data from UIWebView", TAG);
-        BOOL success = [self moveFile:original to:target];
-        logDebug(@"%@ copy status %d", TAG, success);
-        return success;
-    }
-    else {
-        logDebug(@"%@ found IDB data. Not migrating", TAG);
-        return NO;
-    }
-}
-
-
 - (void)pluginInitialize
 {
     logDebug(@"%@ pluginInitialize()", TAG);
     
     NSDictionary *cdvSettings = self.commandDelegate.settings;
-    self.portNumber = [cdvSettings cordovaSettingForKey:CDV_SETTING_PORT_NUMBER];
-    
-    if([self.portNumber length] == 0) {
-        self.portNumber = DEFAULT_PORT_NUMBER;
+
+    self.originalPortNumber = [cdvSettings cordovaSettingForKey:SETTING_ORIGINAL_PORT_NUMBER];
+    if([self.originalPortNumber length] == 0) {
+        self.originalPortNumber = DEFAULT_ORIGINAL_PORT_NUMBER;
     }
     
-    [self migrateWebSQL];
+    self.originalHostname = [cdvSettings cordovaSettingForKey:SETTING_ORIGINAL_HOSTNAME];
+    if([self.originalHostname length] == 0) {
+        self.originalHostname = DEFAULT_ORIGINAL_HOSTNAME;
+    }
+    
+    self.originalScheme = [cdvSettings cordovaSettingForKey:SETTING_ORIGINAL_SCHEME];
+    if([self.originalScheme length] == 0) {
+        self.originalScheme = DEFAULT_ORIGINAL_SCHEME;
+    }
+
+    self.targetPortNumber = [cdvSettings cordovaSettingForKey:SETTING_TARGET_PORT_NUMBER];
+    if([self.targetPortNumber length] == 0) {
+        self.targetPortNumber = DEFAULT_TARGET_PORT_NUMBER;
+    }
+    
+    self.targetHostname = [cdvSettings cordovaSettingForKey:SETTING_TARGET_HOSTNAME];
+    if([self.targetHostname length] == 0) {
+        self.targetHostname = DEFAULT_TARGET_HOSTNAME;
+    }
+    
+    self.targetScheme = [cdvSettings cordovaSettingForKey:SETTING_TARGET_SCHEME];
+    if([self.targetScheme length] == 0) {
+        self.targetScheme = DEFAULT_TARGET_SCHEME;
+    }
+
     [self migrateLocalStorage];
-    [self migrateIndexedDB];
     
     logDebug(@"%@ end pluginInitialize()", TAG);
 }

--- a/src/ios/MigrateStorage.m
+++ b/src/ios/MigrateStorage.m
@@ -104,11 +104,25 @@
     
     NSString *targetLocalStorageFilePath = [[appLibraryFolder stringByAppendingPathComponent:LOCALSTORAGE_DIRPATH] stringByAppendingPathComponent:targetLocalStorageFileName];
     
-    logDebug(@"%@ LocalStorage original %@", TAG, original);
-    logDebug(@"%@ LocalStorage target %@", TAG, target);
+    logDebug(@"%@ LocalStorage original %@", TAG, originalLocalStorageFilePath);
+    logDebug(@"%@ LocalStorage target %@", TAG, targetLocalStorageFilePath);
+    
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    if ([fileManager fileExistsAtPath:originalLocalStorageFilePath]) {
+        logDebug(@"%@ LocalStorage target exists!", TAG);
+    } else {
+        logDebug(@"%@ LocalStorage target does not exist!", TAG);
+    }
+
+    if ([fileManager fileExistsAtPath:targetLocalStorageFilePath]) {
+        logDebug(@"%@ LocalStorage original exists!", TAG);
+    } else {
+        logDebug(@"%@ LocalStorage original does not exist!", TAG);
+    }
     
     // Only copy data if no existing localstorage data exists yet for wkwebview
-    if (![[NSFileManager defaultManager] fileExistsAtPath:targetLocalStorageFilePath]) {
+    if (![fileManager fileExistsAtPath:targetLocalStorageFilePath]) {
         logDebug(@"%@ No existing localstorage data found for WKWebView. Migrating data from UIWebView", TAG);
         BOOL success1 = [self moveFile:originalLocalStorageFilePath to:targetLocalStorageFilePath];
         BOOL success2 = [self moveFile:[originalLocalStorageFilePath stringByAppendingString:@"-shm"] to:[targetLocalStorageFilePath stringByAppendingString:@"-shm"]];
@@ -117,7 +131,7 @@
         success = success1 && success2 && success3;
     }
     else {
-        logDebug(@"%@ found LocalStorage data. not migrating", TAG);
+        logDebug(@"%@ found existing target LocalStorage data. Not migrating.", TAG);
         success = NO;
     }
     

--- a/src/ios/MigrateStorage.m
+++ b/src/ios/MigrateStorage.m
@@ -19,7 +19,7 @@
 
 #define DEFAULT_TARGET_HOSTNAME @"localhost"
 #define DEFAULT_TARGET_SCHEME @"ionic"
-#define DEFAULT_TARGET_PORT_NUMBER @""
+#define DEFAULT_TARGET_PORT_NUMBER @"0"
 
 #define DEFAULT_ORIGINAL_HOSTNAME @"localhost"
 #define DEFAULT_ORIGINAL_SCHEME @"http"
@@ -46,20 +46,12 @@
 
 - (NSString*)getOriginalPath
 {
-    NSString *path = [NSString stringWithFormat:@"%@_%@", self.originalScheme, self.originalHostname];
-    if (self.originalPortNumber) {
-        path = [path stringByAppendingFormat: @"_%@", self.originalPortNumber];
-    }
-    return path;
+    return [NSString stringWithFormat:@"%@_%@_%@", self.originalScheme, self.originalHostname, self.originalPortNumber];
 }
 
 - (NSString*)getTargetPath
 {
-    NSString *path = [NSString stringWithFormat:@"%@_%@", self.targetScheme, self.targetHostname];
-    if (self.targetPortNumber) {
-        path = [path stringByAppendingFormat: @"_%@", self.targetPortNumber];
-    }
-    return path;
+    return [NSString stringWithFormat:@"%@_%@_%@", self.targetScheme, self.targetHostname, self.targetPortNumber];
 }
 
 - (BOOL)moveFile:(NSString*)src to:(NSString*)dest


### PR DESCRIPTION
With our upgrade from cordova-plugin-ionic-webview@2.x.x to cordova-plugin-ionic-webview@4.x.x, localstorage gets wiped, and thus users get logged out. This is because the host, domain, and port of the internal ionic HTTP server have changed, so a new localstorage file is used. 

This is a fork of a plugin which is intended to migrate from UIWebView to WkWebView. I've modified it to also support WkWebView->WkWebView migrations from one localstorage domain to another. 